### PR TITLE
add error handling when fetching medium posts

### DIFF
--- a/src/app/pages/home/home.tsx
+++ b/src/app/pages/home/home.tsx
@@ -2,21 +2,25 @@ import React, { useEffect, useState, useMemo } from 'react';
 
 import Conditional from '../shared/conditional';
 import Loading from '../shared/loading';
-import Error from '../shared/error';
+import ErrorComponent from '../shared/error';
 
 import layoutStyles from '../../layouts/default/assets/styles.scss';
 
 const dataSourceUrl = 'https://03x2915wpg.execute-api.eu-west-1.amazonaws.com/default/getMediumPosts';
 
 async function getMediumPosts() {
-    const response = await fetch(dataSourceUrl);
-    const result = await response.json();
+    try {
+        const response = await fetch(dataSourceUrl);
+        const result = await response.json();
 
-    const posts = Object.keys(result.payload.references.Post).map(
-        x => result.payload.references.Post[x]
-    );
+        const posts = Object.keys(result.payload.references.Post).map(
+            x => result.payload.references.Post[x]
+        );
 
-    return posts;
+        return posts;
+    } catch (error) {
+        throw new Error("Medium gönderileri çekilemedi");
+    }
 }
 
 function Home() {
@@ -31,7 +35,7 @@ function Home() {
 
     if (error !== null) {
         return (
-            <Error message={error} />
+            <ErrorComponent message={error.message} />
         );
     }
 


### PR DESCRIPTION
Medium postlarını çekerken response ekteki HTML olarak geliyor. Bu responseu json ile parse ederken sıkıntı çıkarıp sitenin ana sayfasının açılmamasına yol açıyor. Bunun için getMediumPosts fonksiyonuna try catch ekledim. Ekte gelen response ve try catch eklendikten sonra sitenin son halini bulabilirsiniz.

Küçük notlar 
* Error reserved word olduğu için component adını değiştirmek zorunda kaldım
 * node 10 da ayağa kaldırabildim projeyi
* lintleyemedim Error: Cannot find module 'eslint-config-eser-react' hatası veriyor

İyi çalışmalar 🙂

<img width="1372" alt="response html" src="https://user-images.githubusercontent.com/31315754/66687444-4beddd80-ec8b-11e9-861c-2d2acc0f9490.png">
<img width="1440" alt="sitenin son hali" src="https://user-images.githubusercontent.com/31315754/66687445-4db7a100-ec8b-11e9-80d1-30b6bd8b7f98.png">
